### PR TITLE
Fix: Proposer calls `newPayload` on Malachite's `AppMsg::Decided`

### DIFF
--- a/app/src/app.rs
+++ b/app/src/app.rs
@@ -220,20 +220,16 @@ pub async fn run(
                 let versioned_hashes: Vec<BlockHash> =
                     block.body.blob_versioned_hashes_iter().copied().collect();
 
-                // If the node is not the proposer, provide the received block
-                // to the execution client (EL).
-                if !state.is_current_proposer() {
-                    let payload_status = engine
-                        .notify_new_block(execution_payload, versioned_hashes)
-                        .await?;
-                    if payload_status.status.is_invalid() {
-                        return Err(eyre!("Invalid payload status: {}", payload_status.status));
-                    }
-                    debug!(
-                        "💡 New block added at height {} with hash: {}",
-                        height, new_block_hash
-                    );
+                let payload_status = engine
+                    .notify_new_block(execution_payload, versioned_hashes)
+                    .await?;
+                if payload_status.status.is_invalid() {
+                    return Err(eyre!("Invalid payload status: {}", payload_status.status));
                 }
+                debug!(
+                    "💡 New block added at height {} with hash: {}",
+                    height, new_block_hash
+                );
 
                 // Notify the execution client (EL) of the new block.
                 // Update the execution head state to this block.

--- a/app/src/app.rs
+++ b/app/src/app.rs
@@ -177,9 +177,13 @@ pub async fn run(
 
                 // Decode bytes into execution payload (a block)
                 let execution_payload = ExecutionPayloadV3::from_ssz_bytes(&block_bytes).unwrap();
+
                 let parent_block_hash = execution_payload.payload_inner.payload_inner.parent_hash;
+
                 let new_block_hash = execution_payload.payload_inner.payload_inner.block_hash;
+
                 assert_eq!(state.latest_block.unwrap().block_hash, parent_block_hash);
+
                 let new_block_timestamp = execution_payload.timestamp();
                 let new_block_number = execution_payload.payload_inner.payload_inner.block_number;
 

--- a/app/src/app.rs
+++ b/app/src/app.rs
@@ -183,6 +183,9 @@ pub async fn run(
                 let new_block_timestamp = execution_payload.timestamp();
                 let new_block_number = execution_payload.payload_inner.payload_inner.block_number;
 
+                let new_block_prev_randao =
+                    execution_payload.payload_inner.payload_inner.prev_randao;
+
                 // Log stats
                 let tx_count = execution_payload
                     .payload_inner
@@ -245,6 +248,7 @@ pub async fn run(
                     block_number: new_block_number,
                     parent_hash: latest_valid_hash,
                     timestamp: new_block_timestamp,
+                    prev_randao: new_block_prev_randao,
                 });
 
                 // Pause briefly before starting next height, just to make following the logs easier

--- a/app/src/state.rs
+++ b/app/src/state.rs
@@ -457,10 +457,6 @@ impl State {
 
         Ok(())
     }
-
-    pub fn is_current_proposer(&self) -> bool {
-        self.current_proposer == Some(self.address)
-    }
 }
 
 /// Re-assemble a [`ProposedValue`] from its [`ProposalParts`].

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   reth0:
-    image: ghcr.io/paradigmxyz/reth:v1.4.1
+    image: ghcr.io/paradigmxyz/reth:v1.1.5
     container_name: reth0
     volumes:
       - ./rethdata/0:/data/reth/execution-data
@@ -41,7 +41,7 @@ services:
       # - "--txpool.pending-max-count=50000" # default=10000
       # - "--txpool.queued-max-count=50000" # default=10000
   reth1:
-    image: ghcr.io/paradigmxyz/reth:v1.4.1
+    image: ghcr.io/paradigmxyz/reth:v1.1.5
     container_name: reth1
     volumes:
       - ./rethdata/1:/data/reth/execution-data
@@ -82,7 +82,7 @@ services:
       # - "--txpool.pending-max-count=50000" # default=10000
       # - "--txpool.queued-max-count=50000" # default=10000
   reth2:
-    image: ghcr.io/paradigmxyz/reth:v1.4.1
+    image: ghcr.io/paradigmxyz/reth:v1.1.5
     container_name: reth2
     volumes:
       - ./rethdata/2:/data/reth/execution-data

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   reth0:
-    image: ghcr.io/paradigmxyz/reth:v1.1.5
+    image: ghcr.io/paradigmxyz/reth:v1.4.1
     container_name: reth0
     volumes:
       - ./rethdata/0:/data/reth/execution-data
@@ -41,7 +41,7 @@ services:
       # - "--txpool.pending-max-count=50000" # default=10000
       # - "--txpool.queued-max-count=50000" # default=10000
   reth1:
-    image: ghcr.io/paradigmxyz/reth:v1.1.5
+    image: ghcr.io/paradigmxyz/reth:v1.4.1
     container_name: reth1
     volumes:
       - ./rethdata/1:/data/reth/execution-data
@@ -82,7 +82,7 @@ services:
       # - "--txpool.pending-max-count=50000" # default=10000
       # - "--txpool.queued-max-count=50000" # default=10000
   reth2:
-    image: ghcr.io/paradigmxyz/reth:v1.1.5
+    image: ghcr.io/paradigmxyz/reth:v1.4.1
     container_name: reth2
     volumes:
       - ./rethdata/2:/data/reth/execution-data

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -35,11 +35,16 @@ impl Engine {
         head_block_hash: BlockHash,
     ) -> eyre::Result<BlockHash> {
         debug!("🟠 set_latest_forkchoice_state: {:?}", head_block_hash);
+
         let ForkchoiceUpdated {
             payload_status,
             payload_id,
         } = self.api.forkchoice_updated(head_block_hash, None).await?;
+
         assert!(payload_id.is_none(), "Payload ID should be None!");
+
+        debug!("➡️ payload_status: {:?}", payload_status);
+
         match payload_status.status {
             PayloadStatusEnum::Valid => Ok(payload_status.latest_valid_hash.unwrap()),
             PayloadStatusEnum::Syncing if payload_status.latest_valid_hash.is_none() => {

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -134,10 +134,4 @@ impl Engine {
             .unwrap_or_else(|_| Duration::from_secs(0))
             .as_secs()
     }
-
-    fn random_prev_randao(&self) -> B256 {
-        let mut bytes = [0u8; 32];
-        rand::thread_rng().fill_bytes(&mut bytes);
-        bytes.into()
-    }
 }

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -78,7 +78,7 @@ impl Engine {
             // The beacon chain generates this value using aggregated validator signatures over time.
             // The mix_hash field in the generated block will be equal to prev_randao.
             // TODO: generate value according to spec.
-            prev_randao: self.random_prev_randao(),
+            prev_randao: latest_block.prev_randao,
 
             // TODO: provide proper address.
             suggested_fee_recipient: Address::repeat_byte(42).to_alloy_address(),
@@ -96,7 +96,9 @@ impl Engine {
             .api
             .forkchoice_updated(block_hash, Some(payload_attributes))
             .await?;
+
         assert_eq!(payload_status.latest_valid_hash, Some(block_hash));
+
         match payload_status.status {
             PayloadStatusEnum::Valid => {
                 assert!(payload_id.is_some(), "Payload ID should be Some!");

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -1,5 +1,4 @@
 use color_eyre::eyre::{self, Ok};
-use rand::RngCore;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tracing::debug;
 

--- a/engine/src/ethereum_rpc.rs
+++ b/engine/src/ethereum_rpc.rs
@@ -3,6 +3,7 @@ use reqwest::{header::CONTENT_TYPE, Client, Url};
 use serde::de::DeserializeOwned;
 use serde_json::json;
 use std::time::Duration;
+use tracing::debug;
 
 use alloy_rpc_types_txpool::{TxpoolInspect, TxpoolStatus};
 
@@ -41,6 +42,8 @@ impl EthereumRPC {
             .header(CONTENT_TYPE, "application/json")
             .json(&body);
         let body: JsonResponseBody = request.send().await?.error_for_status()?.json().await?;
+
+        debug!("response body: {:?}", body);
 
         match (body.result, body.error) {
             (result, None) => serde_json::from_value(result).map_err(Into::into),

--- a/engine/src/json_structures.rs
+++ b/engine/src/json_structures.rs
@@ -114,10 +114,15 @@ impl From<ExecutionPayloadV3> for JsonExecutionPayloadV3 {
 pub struct ExecutionBlock {
     #[serde(rename = "hash")]
     pub block_hash: BlockHash,
+
     #[serde(rename = "number", with = "serde_utils::u64_hex_be")]
     pub block_number: BlockNumber,
+
     pub parent_hash: BlockHash,
+
     #[serde(with = "serde_utils::u64_hex_be")]
     pub timestamp: BlockTimestamp,
+
+    #[serde(rename = "mixHash")]
     pub prev_randao: B256,
 }

--- a/engine/src/json_structures.rs
+++ b/engine/src/json_structures.rs
@@ -119,4 +119,5 @@ pub struct ExecutionBlock {
     pub parent_hash: BlockHash,
     #[serde(with = "serde_utils::u64_hex_be")]
     pub timestamp: BlockTimestamp,
+    pub prev_randao: B256,
 }


### PR DESCRIPTION
### Context
When running Malaketh's txs spammer, despite seeing an increase in the chain height and blocks created/processed we see logs such as:
```
[0] elapsed 1.005s: Sent 1000 txs (117604 bytes); TxpoolStatus { pending: 1000, queued: 0 }
[0] elapsed 2.006s: Sent 1000 txs (117992 bytes); TxpoolStatus { pending: 2000, queued: 0 }
[0] elapsed 3.006s: Sent 1000 txs (117989 bytes); TxpoolStatus { pending: 3001, queued: 0 }
[0] elapsed 4.005s: Sent 1000 txs (117990 bytes); TxpoolStatus { pending: 4000, queued: 0 }
[0] elapsed 5.006s: Sent 1000 txs (117988 bytes); TxpoolStatus { pending: 5000, queued: 0 }
[0] elapsed 6.005s: Sent 1000 txs (117988 bytes); TxpoolStatus { pending: 6002, queued: 0 }
[0] elapsed 7.005s: Sent 1000 txs (117991 bytes); TxpoolStatus { pending: 7000, queued: 0 }
[0] elapsed 8.006s: Sent 1000 txs (117983 bytes); TxpoolStatus { pending: 8000, queued: 0 }
[0] elapsed 9.005s: Sent 1000 txs (117990 bytes); TxpoolStatus { pending: 9001, queued: 0 }
[0] elapsed 10.005s: Sent 1000 txs (117988 bytes); TxpoolStatus { pending: 10000, queued: 0 }
[0] elapsed 11.006s: Sent 999 txs (117868 bytes); 1 failed with {"Server Error -32003: txpool is full": 1}; TxpoolStatus { pending: 10000, queued: 999 }
```
indicating that reth isn't reaping transactions from the mempool.


### Changes
#### Proposer calls `newPayload`
It turns out that, counter-intuitively, when finalizing a block we must call the engine API `newPayload` function on the proposer node as well. Simply calling `forkChoiceUpdated` with the new block hash isn't enough.

My understanding:

- `newPayload` tells reth to validate and store the block in its chain database.
- On non-proposer nodes, calling `newPayload` followed by `forkchoiceUpdated` lets reth know about a new block so that it can store it in its chain DB and updates the chain's head.
- On the proposer node, having called `forkchoiceUpdated(attrs)` followed by `getPayload` at the beginning of the round isn't enough for reth to be aware of this payload at finalization time. Here too, we must call `newPayload` before calling `forkchoiceUpdated` to update the chain head.

However, in Malaketh's current implementation, the proposer never calls `newPayload`, so reth never writes the block to its chain DB; therefore the block's transactions never get removed from the mempool.

Somehow, the version of reth that malaketh uses (`v1.1.5`) fails silently, but the latest versions return a 
```
PayloadStatus { status: Syncing, latest_valid_hash: None }
``` 
response if you call `forkChoiceUpdated` on the proposer without a prior `newPayload`. According to the docs, `Syncing` means reth doesn’t have the information needed to process the request. In this case, I guess it means it hasn't seen the block hash (i.e., not stored in its chain DB) that we are telling it to process with `forkchoiceUpdated`. This is counter-intuitive because, on the proposer, we expect that reth has seen the hash, given that it just created it for us. But it seems that's not the case 🤷 

Once you add the missing `newPayload call` on the proposer when processing Malachite's `AppMsg::Decided`, reth processes the transactions in the mempool, and the call to `forkchoiceUpdated` succeeds.

#### Update reth's dependency to `v1.4.1`
- As explained above, the newer version returns a useful response to erroneous engine API calls.
- We take advantage of reth's flag `AwaitInProgress` added [here](https://github.com/paradigmxyz/reth/pull/15161).